### PR TITLE
purchaseUri can be null

### DIFF
--- a/lib/src/models/mtg_card.dart
+++ b/lib/src/models/mtg_card.dart
@@ -306,7 +306,7 @@ class MtgCard {
 
   /// An object providing URIs to this card’s listing on
   /// major marketplaces.
-  final Map<String, Uri> purchaseUris;
+  final Map<String, Uri>? purchaseUris;
 
   /// This card’s rarity.
   @JsonKey(unknownEnumValue: Rarity.unknown)

--- a/lib/src/models/mtg_card.g.dart
+++ b/lib/src/models/mtg_card.g.dart
@@ -151,7 +151,7 @@ MtgCard _$MtgCardFromJson(Map<String, dynamic> json) => $checkedCreate(
               (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
           purchaseUris: $checkedConvert(
               'purchase_uris',
-              (v) => (v as Map<String, dynamic>).map(
+              (v) => (v as Map<String, dynamic>?)?.map(
                     (k, e) => MapEntry(k, Uri.parse(e as String)),
                   )),
           rarity: $checkedConvert(


### PR DESCRIPTION
Came across a card tonight that didn't have a purchaseUri object, which threw an error when trying to parse the json.