### PR TITLE
Feature/update various things

### DIFF
--- a/lib/src/models/bulk_data.g.dart
+++ b/lib/src/models/bulk_data.g.dart
@@ -20,7 +20,7 @@ BulkData _$BulkDataFromJson(Map<String, dynamic> json) => $checkedCreate(
               $checkedConvert('download_uri', (v) => Uri.parse(v as String)),
           updatedAt:
               $checkedConvert('updated_at', (v) => DateTime.parse(v as String)),
-          size: $checkedConvert('size', (v) => v as int),
+          size: $checkedConvert('size', (v) => (v as num).toInt()),
           contentType: $checkedConvert('content_type', (v) => v as String),
           contentEncoding:
               $checkedConvert('content_encoding', (v) => v as String),

--- a/lib/src/models/card_face.dart
+++ b/lib/src/models/card_face.dart
@@ -29,6 +29,9 @@ class CardFace {
   @JsonKey(unknownEnumValue: Color.unknown)
   final List<Color>? colors;
 
+  /// This face’s defense, if any.
+  final String? defense;
+
   /// The just-for-fun name printed on the card
   /// (such as for Godzilla series cards).
   final String? flavorName;
@@ -105,6 +108,7 @@ class CardFace {
     this.cmc,
     this.colorIndicator,
     this.colors,
+    this.defense,
     this.flavorName,
     this.flavorText,
     this.illustrationId,

--- a/lib/src/models/card_face.g.dart
+++ b/lib/src/models/card_face.g.dart
@@ -26,6 +26,7 @@ CardFace _$CardFaceFromJson(Map<String, dynamic> json) => $checkedCreate(
                   ?.map((e) => $enumDecode(_$ColorEnumMap, e,
                       unknownValue: Color.unknown))
                   .toList()),
+          defense: $checkedConvert('defense', (v) => v as String?),
           flavorName: $checkedConvert('flavor_name', (v) => v as String?),
           flavorText: $checkedConvert('flavor_text', (v) => v as String?),
           illustrationId:
@@ -89,8 +90,12 @@ const _$LayoutEnumMap = {
   Layout.meld: 'meld',
   Layout.leveler: 'leveler',
   Layout.clazz: 'class',
+  Layout.caze: 'case',
   Layout.saga: 'saga',
   Layout.adventure: 'adventure',
+  Layout.mutate: 'mutate',
+  Layout.prototype: 'prototype',
+  Layout.battle: 'battle',
   Layout.planar: 'planar',
   Layout.scheme: 'scheme',
   Layout.vanguard: 'vanguard',

--- a/lib/src/models/card_identifier.g.dart
+++ b/lib/src/models/card_identifier.g.dart
@@ -30,7 +30,7 @@ CardIdentifierMtgoId _$CardIdentifierMtgoIdFromJson(
       json,
       ($checkedConvert) {
         final val = CardIdentifierMtgoId(
-          $checkedConvert('mtgo_id', (v) => v as int),
+          $checkedConvert('mtgo_id', (v) => (v as num).toInt()),
         );
         return val;
       },
@@ -50,7 +50,7 @@ CardIdentifierMultiverseId _$CardIdentifierMultiverseIdFromJson(
       json,
       ($checkedConvert) {
         final val = CardIdentifierMultiverseId(
-          $checkedConvert('multiverse_id', (v) => v as int),
+          $checkedConvert('multiverse_id', (v) => (v as num).toInt()),
         );
         return val;
       },

--- a/lib/src/models/frame_effect.dart
+++ b/lib/src/models/frame_effect.dart
@@ -63,6 +63,21 @@ enum FrameEffect {
   /// The cards have the Lesson frame effect.
   lesson,
 
+  /// The cards have the Shattered Glass frame effect.
+  shatteredglass,
+
+  /// The cards have More Than Meets the Eye™ marks.
+  convertdfc,
+
+  /// The cards have fan transforming marks.
+  fandfc,
+
+  /// The cards have the Upside Down transforming marks.
+  upsidedowndfc,
+
+  /// The cards have Spree asterisks.
+  spree,
+
   /// Unknown frame effect.
   unknown,
 }

--- a/lib/src/models/layout.dart
+++ b/lib/src/models/layout.dart
@@ -36,15 +36,28 @@ enum Layout {
   /// Cards with Level Up.
   leveler,
 
-  /// Class-type enchantment cards
+  /// Class-type enchantment cards.
   @JsonValue('class')
   clazz,
+
+  /// Case-type enchantment cards.
+  @JsonValue('case')
+  caze,
 
   /// Saga-type cards.
   saga,
 
   /// Cards with an Adventure spell part.
   adventure,
+
+  /// Cards with Mutate.
+  mutate,
+
+  /// Cards with Prototype.
+  prototype,
+
+  /// Battle-type cards.
+  battle,
 
   /// Plane and Phenomenon-type cards.
   planar,

--- a/lib/src/models/mtg_card.dart
+++ b/lib/src/models/mtg_card.dart
@@ -212,6 +212,9 @@ class MtgCard {
   /// The unique identifiers of the illustrators of this card.
   final List<String>? artistIds;
 
+  /// The lit
+  /// [Unfinity attractions](https://scryfall.com/search?q=t%3Aattraction+unique%3Aprints)
+  /// lights on this card, if any.
   final List<int>? attractionLights;
 
   /// Whether this card is found in boosters.

--- a/lib/src/models/mtg_card.dart
+++ b/lib/src/models/mtg_card.dart
@@ -212,6 +212,8 @@ class MtgCard {
   /// The unique identifiers of the illustrators of this card.
   final List<String>? artistIds;
 
+  final List<int>? attractionLights;
+
   /// Whether this card is found in boosters.
   final bool booster;
 
@@ -408,6 +410,7 @@ class MtgCard {
     required this.typeLine,
     this.artist,
     this.artistIds,
+    this.attractionLights,
     required this.booster,
     required this.borderColor,
     required this.cardBackId,

--- a/lib/src/models/mtg_card.g.dart
+++ b/lib/src/models/mtg_card.g.dart
@@ -11,20 +11,26 @@ MtgCard _$MtgCardFromJson(Map<String, dynamic> json) => $checkedCreate(
       json,
       ($checkedConvert) {
         final val = MtgCard(
-          arenaId: $checkedConvert('arena_id', (v) => v as int?),
+          arenaId: $checkedConvert('arena_id', (v) => (v as num?)?.toInt()),
           id: $checkedConvert('id', (v) => v as String),
           lang: $checkedConvert(
               'lang',
               (v) => $enumDecode(_$LanguageEnumMap, v,
                   unknownValue: Language.unknown)),
-          mtgoId: $checkedConvert('mtgo_id', (v) => v as int?),
-          mtgoFoilId: $checkedConvert('mtgo_foil_id', (v) => v as int?),
-          multiverseIds: $checkedConvert('multiverse_ids',
-              (v) => (v as List<dynamic>?)?.map((e) => e as int).toList()),
-          tcgplayerId: $checkedConvert('tcgplayer_id', (v) => v as int?),
-          tcgplyerEtchedId:
-              $checkedConvert('tcgplyer_etched_id', (v) => v as int?),
-          cardmarketId: $checkedConvert('cardmarket_id', (v) => v as int?),
+          mtgoId: $checkedConvert('mtgo_id', (v) => (v as num?)?.toInt()),
+          mtgoFoilId:
+              $checkedConvert('mtgo_foil_id', (v) => (v as num?)?.toInt()),
+          multiverseIds: $checkedConvert(
+              'multiverse_ids',
+              (v) => (v as List<dynamic>?)
+                  ?.map((e) => (e as num).toInt())
+                  .toList()),
+          tcgplayerId:
+              $checkedConvert('tcgplayer_id', (v) => (v as num?)?.toInt()),
+          tcgplyerEtchedId: $checkedConvert(
+              'tcgplyer_etched_id', (v) => (v as num?)?.toInt()),
+          cardmarketId:
+              $checkedConvert('cardmarket_id', (v) => (v as num?)?.toInt()),
           oracleId: $checkedConvert('oracle_id', (v) => v as String),
           printsSearchUri: $checkedConvert(
               'prints_search_uri', (v) => Uri.parse(v as String)),
@@ -62,7 +68,8 @@ MtgCard _$MtgCardFromJson(Map<String, dynamic> json) => $checkedCreate(
                   ?.map((e) => $enumDecode(_$ColorEnumMap, e,
                       unknownValue: Color.unknown))
                   .toList()),
-          edhrecRank: $checkedConvert('edhrec_rank', (v) => v as int?),
+          edhrecRank:
+              $checkedConvert('edhrec_rank', (v) => (v as num?)?.toInt()),
           handModifier: $checkedConvert('hand_modifier', (v) => v as String?),
           keywords: $checkedConvert('keywords',
               (v) => (v as List<dynamic>).map((e) => e as String).toList()),
@@ -91,6 +98,11 @@ MtgCard _$MtgCardFromJson(Map<String, dynamic> json) => $checkedCreate(
           artist: $checkedConvert('artist', (v) => v as String?),
           artistIds: $checkedConvert('artist_ids',
               (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
+          attractionLights: $checkedConvert(
+              'attraction_lights',
+              (v) => (v as List<dynamic>?)
+                  ?.map((e) => (e as num).toInt())
+                  .toList()),
           booster: $checkedConvert('booster', (v) => v as bool),
           borderColor: $checkedConvert(
               'border_color',
@@ -219,6 +231,7 @@ MtgCard _$MtgCardFromJson(Map<String, dynamic> json) => $checkedCreate(
         'producedMana': 'produced_mana',
         'typeLine': 'type_line',
         'artistIds': 'artist_ids',
+        'attractionLights': 'attraction_lights',
         'borderColor': 'border_color',
         'cardBackId': 'card_back_id',
         'collectorNumber': 'collector_number',
@@ -290,8 +303,12 @@ const _$LayoutEnumMap = {
   Layout.meld: 'meld',
   Layout.leveler: 'leveler',
   Layout.clazz: 'class',
+  Layout.caze: 'case',
   Layout.saga: 'saga',
   Layout.adventure: 'adventure',
+  Layout.mutate: 'mutate',
+  Layout.prototype: 'prototype',
+  Layout.battle: 'battle',
   Layout.planar: 'planar',
   Layout.scheme: 'scheme',
   Layout.vanguard: 'vanguard',
@@ -342,6 +359,11 @@ const _$FrameEffectEnumMap = {
   FrameEffect.etched: 'etched',
   FrameEffect.snow: 'snow',
   FrameEffect.lesson: 'lesson',
+  FrameEffect.shatteredglass: 'shatteredglass',
+  FrameEffect.convertdfc: 'convertdfc',
+  FrameEffect.fandfc: 'fandfc',
+  FrameEffect.upsidedowndfc: 'upsidedowndfc',
+  FrameEffect.spree: 'spree',
   FrameEffect.unknown: 'unknown',
 };
 
@@ -408,6 +430,8 @@ const _$SecurityStampEnumMap = {
   SecurityStamp.oval: 'oval',
   SecurityStamp.triangle: 'triangle',
   SecurityStamp.acorn: 'acorn',
+  SecurityStamp.circle: 'circle',
   SecurityStamp.arena: 'arena',
+  SecurityStamp.heart: 'heart',
   SecurityStamp.unknown: 'unknown',
 };

--- a/lib/src/models/mtg_set.g.dart
+++ b/lib/src/models/mtg_set.g.dart
@@ -15,7 +15,8 @@ MtgSet _$MtgSetFromJson(Map<String, dynamic> json) => $checkedCreate(
           code: $checkedConvert('code', (v) => v as String),
           mtgoCode: $checkedConvert('mtgo_code', (v) => v as String?),
           arenaCode: $checkedConvert('arena_code', (v) => v as String?),
-          tcgplayerId: $checkedConvert('tcgplayer_id', (v) => v as int?),
+          tcgplayerId:
+              $checkedConvert('tcgplayer_id', (v) => (v as num?)?.toInt()),
           name: $checkedConvert('name', (v) => v as String),
           setType: $checkedConvert(
               'set_type',
@@ -27,8 +28,9 @@ MtgSet _$MtgSetFromJson(Map<String, dynamic> json) => $checkedCreate(
           block: $checkedConvert('block', (v) => v as String?),
           parentSetCode:
               $checkedConvert('parent_set_code', (v) => v as String?),
-          cardCount: $checkedConvert('card_count', (v) => v as int),
-          printedSize: $checkedConvert('printed_size', (v) => v as int?),
+          cardCount: $checkedConvert('card_count', (v) => (v as num).toInt()),
+          printedSize:
+              $checkedConvert('printed_size', (v) => (v as num?)?.toInt()),
           digital: $checkedConvert('digital', (v) => v as bool),
           foilOnly: $checkedConvert('foil_only', (v) => v as bool),
           nonfoilOnly: $checkedConvert('nonfoil_only', (v) => v as bool),

--- a/lib/src/models/paginable_list.g.dart
+++ b/lib/src/models/paginable_list.g.dart
@@ -20,7 +20,8 @@ PaginableList<T> _$PaginableListFromJson<T>(
           hasMore: $checkedConvert('has_more', (v) => v as bool),
           nextPage: $checkedConvert(
               'next_page', (v) => v == null ? null : Uri.parse(v as String)),
-          totalCards: $checkedConvert('total_cards', (v) => v as int?),
+          totalCards:
+              $checkedConvert('total_cards', (v) => (v as num?)?.toInt()),
           warnings: $checkedConvert('warnings',
               (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
         );

--- a/lib/src/models/scryfall_exception.g.dart
+++ b/lib/src/models/scryfall_exception.g.dart
@@ -12,7 +12,7 @@ ScryfallException _$ScryfallExceptionFromJson(Map<String, dynamic> json) =>
       json,
       ($checkedConvert) {
         final val = ScryfallException(
-          status: $checkedConvert('status', (v) => v as int),
+          status: $checkedConvert('status', (v) => (v as num).toInt()),
           code: $checkedConvert('code', (v) => v as String),
           details: $checkedConvert('details', (v) => v as String),
           type: $checkedConvert('type', (v) => v as String?),

--- a/lib/src/models/security_stamp.dart
+++ b/lib/src/models/security_stamp.dart
@@ -12,8 +12,14 @@ enum SecurityStamp {
   /// Acorn security stamp.
   acorn,
 
+  /// Circle security stamp.
+  circle,
+
   /// Arena security stamp.
   arena,
+
+  /// Heart security stamp.
+  heart,
 
   /// Unknown security stamp.
   unknown,

--- a/lib/src/scryfall_api_client.dart
+++ b/lib/src/scryfall_api_client.dart
@@ -997,24 +997,17 @@ class ScryfallApiClient {
   /// with [CatalogType.wordBank].
   Future<Catalog> getWordBank() => getCatalog(CatalogType.wordBank);
 
-  /// **GET** /catalog/creature-types
+  /// **GET** /catalog/supertypes
   ///
   /// Convenience method for calling [getCatalog]
-  /// with [CatalogType.creatureTypes].
-  Future<Catalog> getCreatureTypes() => getCatalog(CatalogType.creatureTypes);
+  /// with [CatalogType.supertypes].
+  Future<Catalog> getSupertypes() => getCatalog(CatalogType.supertypes);
 
-  /// **GET** /catalog/planeswalker-types
+  /// **GET** /catalog/card-types
   ///
   /// Convenience method for calling [getCatalog]
-  /// with [CatalogType.planeswalkerTypes].
-  Future<Catalog> getPlaneswalkerTypes() =>
-      getCatalog(CatalogType.planeswalkerTypes);
-
-  /// **GET** /catalog/land-types
-  ///
-  /// Convenience method for calling [getCatalog]
-  /// with [CatalogType.landTypes].
-  Future<Catalog> getLandTypes() => getCatalog(CatalogType.landTypes);
+  /// with [CatalogType.cardTypes].
+  Future<Catalog> getCardTypes() => getCatalog(CatalogType.cardTypes);
 
   /// **GET** /catalog/artifact-types
   ///
@@ -1022,12 +1015,37 @@ class ScryfallApiClient {
   /// with [CatalogType.artifactTypes].
   Future<Catalog> getArtifactTypes() => getCatalog(CatalogType.artifactTypes);
 
+  /// **GET** /catalog/battle-types
+  ///
+  /// Convenience method for calling [getCatalog]
+  /// with [CatalogType.battleTypes].
+  Future<Catalog> getBattleTypes() => getCatalog(CatalogType.battleTypes);
+
+  /// **GET** /catalog/creature-types
+  ///
+  /// Convenience method for calling [getCatalog]
+  /// with [CatalogType.creatureTypes].
+  Future<Catalog> getCreatureTypes() => getCatalog(CatalogType.creatureTypes);
+
   /// **GET** /catalog/enchantment-types
   ///
   /// Convenience method for calling [getCatalog]
   /// with [CatalogType.enchantmentTypes].
   Future<Catalog> getEnchantmentTypes() =>
       getCatalog(CatalogType.enchantmentTypes);
+
+  /// **GET** /catalog/land-types
+  ///
+  /// Convenience method for calling [getCatalog]
+  /// with [CatalogType.landTypes].
+  Future<Catalog> getLandTypes() => getCatalog(CatalogType.landTypes);
+
+  /// **GET** /catalog/planeswalker-types
+  ///
+  /// Convenience method for calling [getCatalog]
+  /// with [CatalogType.planeswalkerTypes].
+  Future<Catalog> getPlaneswalkerTypes() =>
+      getCatalog(CatalogType.planeswalkerTypes);
 
   /// **GET** /catalog/spell-types
   ///
@@ -1053,12 +1071,6 @@ class ScryfallApiClient {
   /// with [CatalogType.loyalties].
   Future<Catalog> getLoyalties() => getCatalog(CatalogType.loyalties);
 
-  /// **GET** /catalog/watermarks
-  ///
-  /// Convenience method for calling [getCatalog]
-  /// with [CatalogType.watermarks].
-  Future<Catalog> getWatermarks() => getCatalog(CatalogType.watermarks);
-
   /// **GET** /catalog/keyword-abilities
   ///
   /// Convenience method for calling [getCatalog]
@@ -1077,6 +1089,18 @@ class ScryfallApiClient {
   /// Convenience method for calling [getCatalog]
   /// with [CatalogType.abilityWords].
   Future<Catalog> getAbilityWords() => getCatalog(CatalogType.abilityWords);
+
+  /// **GET** /catalog/flavor-words
+  ///
+  /// Convenience method for calling [getCatalog]
+  /// with [CatalogType.flavorWords].
+  Future<Catalog> getFlavorWords() => getCatalog(CatalogType.flavorWords);
+
+  /// **GET** /catalog/watermarks
+  ///
+  /// Convenience method for calling [getCatalog]
+  /// with [CatalogType.watermarks].
+  Future<Catalog> getWatermarks() => getCatalog(CatalogType.watermarks);
 
   /// **GET** /bulk-data
   ///

--- a/lib/src/scryfall_api_client.dart
+++ b/lib/src/scryfall_api_client.dart
@@ -1292,18 +1292,13 @@ enum BulkDataType {
 
 extension on BulkDataType {
   String get urlEncoding {
-    switch (this) {
-      case BulkDataType.oracleCards:
-        return 'oracle-cards';
-      case BulkDataType.uniqueArtwork:
-        return 'unique-artwork';
-      case BulkDataType.defaultCards:
-        return 'default-cards';
-      case BulkDataType.allCards:
-        return 'all-cards';
-      case BulkDataType.rulings:
-        return 'rulings';
-    }
+    return switch (this) {
+      BulkDataType.oracleCards => 'oracle-cards',
+      BulkDataType.uniqueArtwork => 'unique-artwork',
+      BulkDataType.defaultCards => 'default-cards',
+      BulkDataType.allCards => 'all-cards',
+      BulkDataType.rulings => 'rulings',
+    };
   }
 }
 
@@ -1320,20 +1315,29 @@ enum CatalogType {
   /// appear in a card name.
   wordBank,
 
-  /// All creature types.
-  creatureTypes,
+  /// All supertypes.
+  supertypes,
 
-  /// All Planeswalker types.
-  planeswalkerTypes,
-
-  /// All Land types.
-  landTypes,
+  /// All card types.
+  cardTypes,
 
   /// All artifact types.
   artifactTypes,
 
+  /// All battle types.
+  battleTypes,
+
+  /// All creature types.
+  creatureTypes,
+
   /// All enchantment types.
   enchantmentTypes,
+
+  /// All Land types.
+  landTypes,
+
+  /// All Planeswalker types.
+  planeswalkerTypes,
 
   /// All spell types.
   spellTypes,
@@ -1347,9 +1351,6 @@ enum CatalogType {
   /// All possible values for a Planeswalker’s loyalty.
   loyalties,
 
-  /// All card watermarks.
-  watermarks,
-
   /// All keyword abilities.
   keywordAbilities,
 
@@ -1358,44 +1359,38 @@ enum CatalogType {
 
   /// All ability words.
   abilityWords,
+
+  /// All flavor words.
+  flavorWords,
+
+  /// All card watermarks.
+  watermarks,
 }
 
 extension on CatalogType {
   String get urlEncoding {
-    switch (this) {
-      case CatalogType.cardNames:
-        return 'card-names';
-      case CatalogType.artistNames:
-        return 'artist-names';
-      case CatalogType.wordBank:
-        return 'word-bank';
-      case CatalogType.creatureTypes:
-        return 'creature-types';
-      case CatalogType.planeswalkerTypes:
-        return 'planeswalker-types';
-      case CatalogType.landTypes:
-        return 'land-types';
-      case CatalogType.artifactTypes:
-        return 'artifact-types';
-      case CatalogType.enchantmentTypes:
-        return 'enchantment-types';
-      case CatalogType.spellTypes:
-        return 'spell-types';
-      case CatalogType.powers:
-        return 'powers';
-      case CatalogType.toughnesses:
-        return 'toughnesses';
-      case CatalogType.loyalties:
-        return 'loyalties';
-      case CatalogType.watermarks:
-        return 'watermarks';
-      case CatalogType.keywordAbilities:
-        return 'keyword-abilities';
-      case CatalogType.keywordActions:
-        return 'keyword-actions';
-      case CatalogType.abilityWords:
-        return 'ability-words';
-    }
+    return switch (this) {
+      CatalogType.cardNames => 'card-names',
+      CatalogType.artistNames => 'artist-names',
+      CatalogType.wordBank => 'word-bank',
+      CatalogType.supertypes => 'supertypes',
+      CatalogType.cardTypes => 'card-types',
+      CatalogType.artifactTypes => 'artifact-types',
+      CatalogType.battleTypes => 'battle-types',
+      CatalogType.creatureTypes => 'creature-types',
+      CatalogType.enchantmentTypes => 'enchantment-types',
+      CatalogType.landTypes => 'land-types',
+      CatalogType.planeswalkerTypes => 'planeswalker-types',
+      CatalogType.spellTypes => 'spell-types',
+      CatalogType.powers => 'powers',
+      CatalogType.toughnesses => 'toughnesses',
+      CatalogType.loyalties => 'loyalties',
+      CatalogType.keywordAbilities => 'keyword-abilities',
+      CatalogType.keywordActions => 'keyword-actions',
+      CatalogType.abilityWords => 'ability-words',
+      CatalogType.flavorWords => 'flavor-words',
+      CatalogType.watermarks => 'watermarks',
+    };
   }
 }
 
@@ -1453,20 +1448,14 @@ enum ImageVersion {
 
 extension on ImageVersion {
   String get json {
-    switch (this) {
-      case ImageVersion.small:
-        return 'small';
-      case ImageVersion.normal:
-        return 'normal';
-      case ImageVersion.large:
-        return 'large';
-      case ImageVersion.png:
-        return 'png';
-      case ImageVersion.artCrop:
-        return 'art_crop';
-      case ImageVersion.borderCrop:
-        return 'border_crop';
-    }
+    return switch (this) {
+      ImageVersion.small => 'small',
+      ImageVersion.normal => 'normal',
+      ImageVersion.large => 'large',
+      ImageVersion.png => 'png',
+      ImageVersion.artCrop => 'art_crop',
+      ImageVersion.borderCrop => 'border_crop',
+    };
   }
 }
 
@@ -1582,13 +1571,10 @@ enum SortingDirection {
 
 extension on SortingDirection {
   String get json {
-    switch (this) {
-      case SortingDirection.ascending:
-        return 'asc';
-      case SortingDirection.descending:
-        return 'desc';
-      default:
-        return 'auto';
-    }
+    return switch (this) {
+      SortingDirection.ascending => 'asc',
+      SortingDirection.descending => 'desc',
+      _ => 'auto',
+    };
   }
 }

--- a/test/scryfall_api_client_test.dart
+++ b/test/scryfall_api_client_test.dart
@@ -1827,22 +1827,26 @@ void main() {
         await testCategoryType(CatalogType.cardNames, 'card-names');
         await testCategoryType(CatalogType.artistNames, 'artist-names');
         await testCategoryType(CatalogType.wordBank, 'word-bank');
+        await testCategoryType(CatalogType.supertypes, 'supertypes');
+        await testCategoryType(CatalogType.cardTypes, 'card-types');
+        await testCategoryType(CatalogType.artifactTypes, 'artifact-types');
+        await testCategoryType(CatalogType.battleTypes, 'battle-types');
         await testCategoryType(CatalogType.creatureTypes, 'creature-types');
         await testCategoryType(
-            CatalogType.planeswalkerTypes, 'planeswalker-types');
-        await testCategoryType(CatalogType.landTypes, 'land-types');
-        await testCategoryType(CatalogType.artifactTypes, 'artifact-types');
-        await testCategoryType(
             CatalogType.enchantmentTypes, 'enchantment-types');
+        await testCategoryType(CatalogType.landTypes, 'land-types');
+        await testCategoryType(
+            CatalogType.planeswalkerTypes, 'planeswalker-types');
         await testCategoryType(CatalogType.spellTypes, 'spell-types');
         await testCategoryType(CatalogType.powers, 'powers');
         await testCategoryType(CatalogType.toughnesses, 'toughnesses');
         await testCategoryType(CatalogType.loyalties, 'loyalties');
-        await testCategoryType(CatalogType.watermarks, 'watermarks');
         await testCategoryType(
             CatalogType.keywordAbilities, 'keyword-abilities');
         await testCategoryType(CatalogType.keywordActions, 'keyword-actions');
         await testCategoryType(CatalogType.abilityWords, 'ability-words');
+        await testCategoryType(CatalogType.flavorWords, 'flavor-words');
+        await testCategoryType(CatalogType.watermarks, 'watermarks');
       });
 
       test('throws ScryfallException on non-200 response', () async {

--- a/test/scryfall_api_client_test.dart
+++ b/test/scryfall_api_client_test.dart
@@ -1920,26 +1920,17 @@ void main() {
         );
       });
 
-      test('getCreatureTypes called getCatalog with correct argument',
-          () async {
+      test('getSupertypes called getCatalog with correct argument', () async {
         testCatalogConvenienceMethod(
-          scryfallApiClient.getCreatureTypes,
-          'creature-types',
+          scryfallApiClient.getSupertypes,
+          'supertypes',
         );
       });
 
-      test('getPlaneswalkerTypes called getCatalog with correct argument',
-          () async {
+      test('getCardTypes called getCatalog with correct argument', () async {
         testCatalogConvenienceMethod(
-          scryfallApiClient.getPlaneswalkerTypes,
-          'planeswalker-types',
-        );
-      });
-
-      test('getLandTypes called getCatalog with correct argument', () async {
-        testCatalogConvenienceMethod(
-          scryfallApiClient.getLandTypes,
-          'land-types',
+          scryfallApiClient.getCardTypes,
+          'card-types',
         );
       });
 
@@ -1951,11 +1942,41 @@ void main() {
         );
       });
 
+      test('getBattleTypes called getCatalog with correct argument', () async {
+        testCatalogConvenienceMethod(
+          scryfallApiClient.getBattleTypes,
+          'battle-types',
+        );
+      });
+
+      test('getCreatureTypes called getCatalog with correct argument',
+          () async {
+        testCatalogConvenienceMethod(
+          scryfallApiClient.getCreatureTypes,
+          'creature-types',
+        );
+      });
+
       test('getEnchantmentTypes called getCatalog with correct argument',
           () async {
         testCatalogConvenienceMethod(
           scryfallApiClient.getEnchantmentTypes,
           'enchantment-types',
+        );
+      });
+
+      test('getLandTypes called getCatalog with correct argument', () async {
+        testCatalogConvenienceMethod(
+          scryfallApiClient.getLandTypes,
+          'land-types',
+        );
+      });
+
+      test('getPlaneswalkerTypes called getCatalog with correct argument',
+          () async {
+        testCatalogConvenienceMethod(
+          scryfallApiClient.getPlaneswalkerTypes,
+          'planeswalker-types',
         );
       });
 
@@ -1987,13 +2008,6 @@ void main() {
         );
       });
 
-      test('getWatermarks called getCatalog with correct argument', () async {
-        testCatalogConvenienceMethod(
-          scryfallApiClient.getWatermarks,
-          'watermarks',
-        );
-      });
-
       test('getKeywordAbilities called getCatalog with correct argument',
           () async {
         testCatalogConvenienceMethod(
@@ -2014,6 +2028,20 @@ void main() {
         testCatalogConvenienceMethod(
           scryfallApiClient.getAbilityWords,
           'ability-words',
+        );
+      });
+
+      test('getFlavorWords called getCatalog with correct argument', () async {
+        testCatalogConvenienceMethod(
+          scryfallApiClient.getFlavorWords,
+          'flavor-words',
+        );
+      });
+
+      test('getWatermarks called getCatalog with correct argument', () async {
+        testCatalogConvenienceMethod(
+          scryfallApiClient.getWatermarks,
+          'watermarks',
         );
       });
     });


### PR DESCRIPTION
Adds things I noticed were missing compared to the Scryfall API as of 2025.

* CardFace
    * defense

* FrameEffect
    * shatteredglass
    * fandfc
    * upsidedowndfc
    * spree

* Layout
    * caze (really "case" - follows the same reserved word workaround as "clazz")
    * mutate
    * prototype
    * battle

* MtgCard
    * attractionLights

* CatalogType
    * supertypes (notice this is _not_ "superTypes" with a capital "T" - the URL is `supertypes` without a dash)
    * cardTypes
    * battleTypes
    * flavorWords

* Reorders the CatalogTypes to be the same order shown in Scryfall API
* Changes switch statements with a bunch of `return` to use switch expression
* Adds some testing
